### PR TITLE
Fix sha256sum of package

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -7,8 +7,7 @@ RUN apk add --no-cache openjdk11-jre bash
 
 RUN apk add --no-cache -t .build-deps wget ca-certificates unzip \
     && wget --progress=bar:force -O /tmp/ghidra.zip https://www.ghidra-sre.org/ghidra_9.0.4_PUBLIC_20190516.zip \
-    && sha256sum /tmp/ghidra.zip \
-    # && echo "${GHIDRA_SHA} /tmp/ghidra.zip" | sha256sum -c - \
+    && echo "${GHIDRA_SHA}  /tmp/ghidra.zip" | sha256sum -c - \
     && unzip /tmp/ghidra.zip \
     && mv ghidra_${VERSION} /ghidra \
     && chmod +x /ghidra/ghidraRun \


### PR DESCRIPTION
Not sure why it's commented out currently and the `shasum` command is just called directly (but output not consumed). Fixed this for you -- note that there are two spaced between the sha256 and the file to hash in alpine.