### PR TITLE
Improve beta build and bolster gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,106 @@
 *.bu
 *.decompressed
-.vscode
 dyld_shared_cache*
 System
 projects
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk

--- a/Dockerfile.beta
+++ b/Dockerfile.beta
@@ -1,13 +1,31 @@
 FROM gradle:jdk11 as builder
 
-ENV GITHUB_URL https://github.com/NationalSecurityAgency/ghidra.git
+ENV GITHUB_URL https://api.github.com/repos/NationalSecurityAgency/ghidra/tarball
 
-RUN apt-get update && apt-get install -y curl git bison flex build-essential unzip
-
-RUN echo "[+] Cloning Ghidra..." \
-    && git clone ${GITHUB_URL} /root/git/ghidra
+RUN apt-get update --quiet \
+    && DEBIAN_FRONTEND=noninteractive \
+        apt-get install --yes --quiet --no-install-recommends \
+            bash \
+            bison \
+            curl \
+            docbook-xsl \
+            flex \
+            fop \
+            g++ \
+            gcc \
+            git \
+            libc6-dev \
+            make \
+            sed \
+            tar \
+            unzip \
+            xsltproc \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /root/git/ghidra
+
+RUN echo "[+] Getting Ghidra Source..." \
+    && curl -sSL ${GITHUB_URL} | tar -xz --strip-components=1
 
 RUN echo "[+] Downloading dependencies..." \
     && gradle --init-script gradle/support/fetchDependencies.gradle init


### PR DESCRIPTION
* .gitignore: Use defaults from `gitignore.io` for common editors and
  environments
* Dockerfile.beta: grab the tarball of the Ghidra source versus getting
  the entire Git histroy unnecessarily (10 sec versus 20 sec on my
  connection)
* Use Dockerfile Dest Practices for apt installs:
  https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run
  * `--no-install-recommends`
  * sort packages each on own line
  * remove apt cache
* Include packages to build GhidraDocs