### PR TITLE
Add 9.2.1 upgrade and install requests to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
 FROM openjdk:11-jdk-slim
 
-ENV VERSION 9.2_PUBLIC
-ENV GHIDRA_SHA ffebd3d87bc7c6d9ae1766dd3293d1fdab3232a99b170f8ea8b57497a1704ff6
-
-RUN apt-get update && apt-get install -y fontconfig libxrender1 libxtst6 libxi6 wget unzip --no-install-recommends \
-    && wget --progress=bar:force -O /tmp/ghidra.zip https://ghidra-sre.org/ghidra_9.2_PUBLIC_20201113.zip \
+ENV VERSION 9.2.1_PUBLIC
+ENV GHIDRA_SHA cfaeb2b5938dec90388e936f63600ad345d41b509ffed4727142ba9ed44cb5e8
+RUN apt-get update && apt-get install -y fontconfig libxrender1 libxtst6 libxi6 wget unzip python-requests --no-install-recommends \
+    && wget --progress=bar:force -O /tmp/ghidra.zip https://ghidra-sre.org/ghidra_9.2.1_PUBLIC_20201215.zip \
     && echo "$GHIDRA_SHA /tmp/ghidra.zip" | sha256sum -c - \
     && unzip /tmp/ghidra.zip \
     && mv ghidra_${VERSION} /ghidra \


### PR DESCRIPTION
Upgraded Dockerfile to Ghidra 9.2.1 and added python-requests install to support Ghidra http enabled scripts.