### PR TITLE
Add configurable -ip flag and -u as default

### DIFF
--- a/10/entrypoint.sh
+++ b/10/entrypoint.sh
@@ -6,6 +6,7 @@ if [ "$1" = 'server' ]; then
   shift
   # Add users
   GHIDRA_USERS=${GHIDRA_USERS:-admin}
+  GHIDRA_IP=${GHIDRA_IP:-0.0.0.0}
   if [ ! -e "/repos/users" ] && [ ! -z "${GHIDRA_USERS}" ]; then
     mkdir -p /repos/~admin
     for user in ${GHIDRA_USERS}; do

--- a/10/server.conf
+++ b/10/server.conf
@@ -123,7 +123,10 @@ ghidra.repositories.dir=/repos
 #                       used to store repositories.  Use of this variable to define the
 #                       repositories directory must be retained.
 wrapper.app.parameter.1=-a0
-wrapper.app.parameter.2=${ghidra.repositories.dir}
+wrapper.app.parameter.2=-u
+wrapper.app.parameter.3=-ip
+wrapper.app.parameter.4=${GHIDRA_IP}
+wrapper.app.parameter.5=${ghidra.repositories.dir}
 
 # Establish server process owner
 # This should only be used when installing as a service using a nologin

--- a/9/entrypoint.sh
+++ b/9/entrypoint.sh
@@ -6,6 +6,7 @@ if [ "$1" = 'server' ]; then
   shift
   # Add users
   GHIDRA_USERS=${GHIDRA_USERS:-admin}
+  GHIDRA_IP=${GHIDRA_IP:-0.0.0.0}
   if [ ! -e "/repos/users" ] && [ ! -z "${GHIDRA_USERS}" ]; then
     mkdir -p /repos/~admin
     for user in ${GHIDRA_USERS}; do

--- a/9/server.conf
+++ b/9/server.conf
@@ -123,7 +123,10 @@ ghidra.repositories.dir=/repos
 #                       used to store repositories.  Use of this variable to define the
 #                       repositories directory must be retained.
 wrapper.app.parameter.1=-a0
-wrapper.app.parameter.2=${ghidra.repositories.dir}
+wrapper.app.parameter.2=-u
+wrapper.app.parameter.3=-ip
+wrapper.app.parameter.4=${GHIDRA_IP}
+wrapper.app.parameter.5=${ghidra.repositories.dir}
 
 # Establish server process owner
 # This should only be used when installing as a service using a nologin

--- a/alpine/entrypoint.sh
+++ b/alpine/entrypoint.sh
@@ -6,6 +6,7 @@ if [ "$1" = 'server' ]; then
   shift
   # Add users
   GHIDRA_USERS=${GHIDRA_USERS:-admin}
+  GHIDRA_IP=${GHIDRA_IP:-0.0.0.0}
   if [ ! -e "/repos/users" ] && [ ! -z "${GHIDRA_USERS}" ]; then
     mkdir -p /repos/~admin
     for user in ${GHIDRA_USERS}; do

--- a/alpine/server.conf
+++ b/alpine/server.conf
@@ -123,7 +123,10 @@ ghidra.repositories.dir=/repos
 #                       used to store repositories.  Use of this variable to define the
 #                       repositories directory must be retained.
 wrapper.app.parameter.1=-a0
-wrapper.app.parameter.2=${ghidra.repositories.dir}
+wrapper.app.parameter.2=-u
+wrapper.app.parameter.3=-ip
+wrapper.app.parameter.4=${GHIDRA_IP}
+wrapper.app.parameter.5=${ghidra.repositories.dir}
 
 # Establish server process owner
 # This should only be used when installing as a service using a nologin

--- a/beta/entrypoint.sh
+++ b/beta/entrypoint.sh
@@ -6,6 +6,7 @@ if [ "$1" = 'server' ]; then
   shift
   # Add users
   GHIDRA_USERS=${GHIDRA_USERS:-admin}
+  GHIDRA_IP=${GHIDRA_IP:-0.0.0.0}
   if [ ! -e "/repos/users" ] && [ ! -z "${GHIDRA_USERS}" ]; then
     mkdir -p /repos/~admin
     for user in ${GHIDRA_USERS}; do

--- a/beta/server.conf
+++ b/beta/server.conf
@@ -123,7 +123,10 @@ ghidra.repositories.dir=/repos
 #                       used to store repositories.  Use of this variable to define the
 #                       repositories directory must be retained.
 wrapper.app.parameter.1=-a0
-wrapper.app.parameter.2=${ghidra.repositories.dir}
+wrapper.app.parameter.2=-u
+wrapper.app.parameter.3=-ip
+wrapper.app.parameter.4=${GHIDRA_IP}
+wrapper.app.parameter.5=${ghidra.repositories.dir}
 
 # Establish server process owner
 # This should only be used when installing as a service using a nologin

--- a/bindiff/entrypoint.sh
+++ b/bindiff/entrypoint.sh
@@ -6,6 +6,7 @@ if [ "$1" = 'server' ]; then
   shift
   # Add users
   GHIDRA_USERS=${GHIDRA_USERS:-admin}
+  GHIDRA_IP=${GHIDRA_IP:-0.0.0.0}
   if [ ! -e "/repos/users" ] && [ ! -z "${GHIDRA_USERS}" ]; then
     mkdir -p /repos/~admin
     for user in ${GHIDRA_USERS}; do

--- a/bindiff/server.conf
+++ b/bindiff/server.conf
@@ -123,7 +123,10 @@ ghidra.repositories.dir=/repos
 #                       used to store repositories.  Use of this variable to define the
 #                       repositories directory must be retained.
 wrapper.app.parameter.1=-a0
-wrapper.app.parameter.2=${ghidra.repositories.dir}
+wrapper.app.parameter.2=-u
+wrapper.app.parameter.3=-ip
+wrapper.app.parameter.4=${GHIDRA_IP}
+wrapper.app.parameter.5=${ghidra.repositories.dir}
 
 # Establish server process owner
 # This should only be used when installing as a service using a nologin

--- a/nightly/entrypoint.sh
+++ b/nightly/entrypoint.sh
@@ -6,6 +6,7 @@ if [ "$1" = 'server' ]; then
   shift
   # Add users
   GHIDRA_USERS=${GHIDRA_USERS:-admin}
+  GHIDRA_IP=${GHIDRA_IP:-0.0.0.0}
   if [ ! -e "/repos/users" ] && [ ! -z "${GHIDRA_USERS}" ]; then
     mkdir -p /repos/~admin
     for user in ${GHIDRA_USERS}; do

--- a/nightly/server.conf
+++ b/nightly/server.conf
@@ -123,7 +123,10 @@ ghidra.repositories.dir=/repos
 #                       used to store repositories.  Use of this variable to define the
 #                       repositories directory must be retained.
 wrapper.app.parameter.1=-a0
-wrapper.app.parameter.2=${ghidra.repositories.dir}
+wrapper.app.parameter.2=-u
+wrapper.app.parameter.3=-ip
+wrapper.app.parameter.4=${GHIDRA_IP}
+wrapper.app.parameter.5=${ghidra.repositories.dir}
 
 # Establish server process owner
 # This should only be used when installing as a service using a nologin

--- a/pkg/entrypoint.sh
+++ b/pkg/entrypoint.sh
@@ -6,6 +6,7 @@ if [ "$1" = 'server' ]; then
   shift
   # Add users
   GHIDRA_USERS=${GHIDRA_USERS:-admin}
+  GHIDRA_IP=${GHIDRA_IP:-0.0.0.0}
   if [ ! -e "/repos/users" ] && [ ! -z "${GHIDRA_USERS}" ]; then
     mkdir -p /repos/~admin
     for user in ${GHIDRA_USERS}; do

--- a/pkg/server.conf
+++ b/pkg/server.conf
@@ -123,7 +123,10 @@ ghidra.repositories.dir=/repos
 #                       used to store repositories.  Use of this variable to define the
 #                       repositories directory must be retained.
 wrapper.app.parameter.1=-a0
-wrapper.app.parameter.2=${ghidra.repositories.dir}
+wrapper.app.parameter.2=-u
+wrapper.app.parameter.3=-ip
+wrapper.app.parameter.4=${GHIDRA_IP}
+wrapper.app.parameter.5=${ghidra.repositories.dir}
 
 # Establish server process owner
 # This should only be used when installing as a service using a nologin


### PR DESCRIPTION
Hello, this PR adds ability to set `-ip` flag from environment variables (useful for non-localhost deployments). To not break compatibility it defaults to `0.0.0.0` if not specified.

Additionally `-u` flag is added, as it's quite painful to work around it in non-local deployments and doesn't hurt too much in local deployments.