### PR TITLE
Add Arm builds to nightly

### DIFF
--- a/.github/workflows/docker-image-nightly.yml
+++ b/.github/workflows/docker-image-nightly.yml
@@ -22,6 +22,14 @@ jobs:
         uses: actions/checkout@v3
 
       -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      -
         name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v4
@@ -57,3 +65,4 @@ jobs:
             ghcr.io/blacktop/ghidra:10-nightly
             ghcr.io/blacktop/ghidra:nightly
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Adds arm build to nightly. This works as the ghidra arm binaries will be built by the compiler.